### PR TITLE
Fix body stmts

### DIFF
--- a/src/msc/FunctionInfo.java
+++ b/src/msc/FunctionInfo.java
@@ -35,15 +35,15 @@ public class FunctionInfo {
         return returnType;
     }
     public DataType getReturnDataType() {
-        if(this.returnType.equals("BOOLEAN")) {
+        if(this.returnType.equals("Boolean")) {
             return DataType.BOOLEAN;
-        } else if(this.returnType.equals("STRING")) {
+        } else if(this.returnType.equals("String")) {
             return DataType.STRING;
-        } else if(this.returnType.equals("INTEGER")) {
+        } else if(this.returnType.equals("Integer")) {
             return DataType.INTEGER;
-        } else if(this.returnType.equals("DOUBLE")) {
+        } else if(this.returnType.equals("Double")) {
             return DataType.DOUBLE;
-        } else if(this.returnType.equals("VOID")) {
+        } else if(this.returnType.equals("Void")) {
             return DataType.VOID;
         } else {
             return null;    // maybe throw exception? this shouldn't be possible tho

--- a/src/msc/FunctionInfo.java
+++ b/src/msc/FunctionInfo.java
@@ -34,6 +34,21 @@ public class FunctionInfo {
     public String getReturnType() {
         return returnType;
     }
+    public DataType getReturnDataType() {
+        if(this.returnType.equals("BOOLEAN")) {
+            return DataType.BOOLEAN;
+        } else if(this.returnType.equals("STRING")) {
+            return DataType.STRING;
+        } else if(this.returnType.equals("INTEGER")) {
+            return DataType.INTEGER;
+        } else if(this.returnType.equals("DOUBLE")) {
+            return DataType.DOUBLE;
+        } else if(this.returnType.equals("VOID")) {
+            return DataType.VOID;
+        } else {
+            return null;    // maybe throw exception? this shouldn't be possible tho
+        }
+    }
 
     public HashMap<String, String> getParameterTypes() {
         return parameterTypes;

--- a/src/nodes/BodyNode.java
+++ b/src/nodes/BodyNode.java
@@ -88,6 +88,37 @@ public class BodyNode implements JottTree {
                 throw new SemanticError("Unreachable code after return statement", bodyStmt.getToken());
             }
 
+            bodyStmt.validateTree(symbolTable); // should check return types match in here
+
+            if(bodyStmt.allReturn()) {
+                this.returns = true;
+            }
+            if(bodyStmt.getReturnType() != null) {
+                this.returnType = bodyStmt.getReturnType();
+            }
+        }
+
+        // handle return at end of body
+        this.returnStmt.validateTree(symbolTable);  // should do return typechecking in here
+
+        if(this.returnStmt.getReturnType() != null) {
+            if(this.returns == true) {
+                // all paths return before the end but another exists
+                throw new SemanticError("Unreachable return at end", this.returnStmt.getToken());
+            }
+
+            this.returns = true;    // all paths return if return is at end of body
+            this.returnType = this.returnStmt.getReturnType();
+        }
+
+        return true;
+
+        /*
+        for(BodyStmtNode bodyStmt: this.bodyStmts) {
+            if(this.returns == true) {
+                throw new SemanticError("Unreachable code after return statement", bodyStmt.getToken());
+            }
+
             bodyStmt.validateTree(symbolTable);
 
             DataType returnType = bodyStmt.getReturnType();
@@ -128,7 +159,7 @@ public class BodyNode implements JottTree {
         }
 
         return true;
-        
+        */
     }
 
     @Override

--- a/src/nodes/ElseIfNode.java
+++ b/src/nodes/ElseIfNode.java
@@ -28,6 +28,10 @@ public class ElseIfNode implements JottTree {
         return this.body.getReturnType();
     }
 
+    public boolean allReturn() {
+        return this.body.allReturn();
+    }
+
     public Token getToken() {
         if(this.body.getToken() != null) {
             return this.body.getToken();

--- a/src/nodes/ElseNode.java
+++ b/src/nodes/ElseNode.java
@@ -30,6 +30,10 @@ public class ElseNode implements JottTree {
         return this.body.getReturnType();
     }
 
+    public boolean allReturn() {
+        return this.body.allReturn();
+    }
+
     public Token getToken() {
         return this.body.getToken();
     }

--- a/src/nodes/FuncBodyNode.java
+++ b/src/nodes/FuncBodyNode.java
@@ -1,13 +1,13 @@
 package nodes;
 
-import java.util.ArrayList;
-
+import errors.SemanticError;
 import errors.SyntaxError;
+import java.util.ArrayList;
+import msc.*;
 import provided.JottParser;
 import provided.JottTree;
 import provided.Token;
 import provided.TokenType;
-import msc.*;
 
 /*
  * Function Body Node
@@ -89,6 +89,18 @@ public class FuncBodyNode implements JottTree {
         this.body.validateTree(symbolTable);
         this.returns = this.body.allReturn();
         this.returnType = this.body.getReturnType();
+
+        String func = symbolTable.current_scope;
+        FunctionInfo info = symbolTable.getFunction(func);
+        DataType funcReturn = info.getReturnDataType();
+        if(funcReturn == null) {
+            throw new SemanticError("Function return should be one of the data types provided or VOID", this.body.getToken());
+        }
+
+        if(funcReturn != DataType.VOID && !this.returns) {
+            // function should return, but not all paths do
+            throw new SemanticError("Function should return " + funcReturn + ", but not all paths are returnable", this.body.getToken());
+        }
 
         return true;
     }

--- a/src/nodes/IfStmtNode.java
+++ b/src/nodes/IfStmtNode.java
@@ -133,6 +133,32 @@ public class IfStmtNode implements BodyStmtNode {
     public boolean validateTree(SymbolTable symbolTable) throws Exception {
         // To be implemented in phase 3
         this.allReturn = true;
+
+        this.expr.validateTree(symbolTable);
+        if(this.expr.getType(symbolTable) != DataType.BOOLEAN) {
+            throw new SemanticError("Expression in if statement must be a boolean", this.expr.getToken());
+        }
+
+        this.body.validateTree(symbolTable);
+        if(!this.body.allReturn()) {
+            this.allReturn = false;
+        }
+        
+        for(ElseIfNode elseIf: this.elseIfs) {
+            elseIf.validateTree(symbolTable);
+            if(!elseIf.allReturn()) {
+                this.allReturn = false;
+            }
+        }
+
+        this.elseBlock.validateTree(symbolTable);
+        if(!this.elseBlock.allReturn()) {
+            this.allReturn = false;
+        }
+
+        return true;
+        /*
+        this.allReturn = true;
         DataType returnVal = null;
 
         this.expr.validateTree(symbolTable);
@@ -193,6 +219,7 @@ public class IfStmtNode implements BodyStmtNode {
         }
 
         return true;
+        */
     }
 
     @Override

--- a/src/nodes/ReturnStmtNode.java
+++ b/src/nodes/ReturnStmtNode.java
@@ -78,14 +78,28 @@ public class ReturnStmtNode implements JottTree {
     public boolean validateTree(SymbolTable symbolTable) throws Exception {
         // Return type matches return statement
         if(this.expr == null) {
-            // body doesn't return
+            // body w/o return is valid
             return true;
         } else {
             this.expr.validateTree(symbolTable);
+
             this.returnType = this.expr.getType(symbolTable);
+
+            String func = symbolTable.current_scope;
+            FunctionInfo info = symbolTable.getFunction(func);
+            DataType funcReturn = info.getReturnDataType();
+            if(funcReturn == null) {
+                throw new SemanticError("Function return should be one of the data types provided or VOID", this.expr.getToken());
+            }
+
             if(this.returnType == null || this.returnType == DataType.VOID) {
                 // should not return null/VOID
                 throw new SemanticError("Functions cannot return VOID", this.expr.getToken());
+            } else if(funcReturn == DataType.VOID) {
+                // function shouldn't return
+                throw new SemanticError("Function with VOID return type shouldn't return", this.expr.getToken());
+            } else if(funcReturn != this.returnType) {
+                throw new SemanticError(func + " should return type " + funcReturn + ", returns " + this.returnType + " instead", this.expr.getToken());
             }
             return true;
         }


### PR DESCRIPTION
- Check if return types match function return type in ReturnStmtNode, throwing a semantic error if return types don't match or function return type is VOID but something is being returned
- Adjusted classes that implement BodyStmtNode accordingly, mainly BodyNode and IfStmtNode with minor changes to elseif/else/while
- Edited FuncBodyNode to check that all paths return if return type is not VOID and no paths return if return type is VOID
- Added method to FunctionInfo to get return type as a DataType enum (returns null if unsuccessful, but this should not happen after the parser)